### PR TITLE
Remove 1 unnecessary stubbing in RequestParameterPolicyEnforcementFilterTests.configureSlf4jLogging

### DIFF
--- a/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
+++ b/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
@@ -196,9 +196,6 @@ public final class RequestParameterPolicyEnforcementFilterTests {
                 .thenReturn("none");
         when(filterConfig.getInitParameter(RequestParameterPolicyEnforcementFilter.PARAMETERS_TO_CHECK))
                 .thenReturn(null);
-        when(filterConfig.getInitParameter(AbstractSecurityFilter.LOGGER_HANDLER_CLASS_NAME))
-                .thenReturn(SLF4JBridgeHandler.class.getCanonicalName());
-
         filter.init(filterConfig);
         assertTrue(filter.getLogger().getHandlers().length > 0);
         assertTrue(filter.getLogger().getHandlers()[0] instanceof SLF4JBridgeHandler);


### PR DESCRIPTION
In our analysis of the project, we observed that the test `RequestParameterPolicyEnforcementFilterTests.configureSlf4jLogging` contains 1 unnecessary stubbing. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.